### PR TITLE
feature/v1.0.3

### DIFF
--- a/src/AndroidServicesApi.php
+++ b/src/AndroidServicesApi.php
@@ -36,8 +36,8 @@ class AndroidServicesApi
     }
 
     /**
-     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2 Purchases.subscriptionsV2
      * @phpcs:enable
      */
@@ -67,8 +67,8 @@ class AndroidServicesApi
     }
 
     /**
-     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans.offers Monetization.subscriptions.basePlans.offers
      * @phpcs:enable
      */
@@ -102,8 +102,8 @@ class AndroidServicesApi
     }
 
     /**
-     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions Monetization.subscriptions
      * @phpcs:enable
      */

--- a/src/AndroidServicesApi.php
+++ b/src/AndroidServicesApi.php
@@ -36,9 +36,11 @@ class AndroidServicesApi
     }
 
     /**
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2 Purchases.subscriptionsV2
-     * */
+     * @phpcs:enable
+     */
     public function getPurchaseSubscriptionV2(
         AndroidPublisherModelInterface $androidPublisherModel
     ): ?SubscriptionPurchaseV2 {
@@ -65,9 +67,11 @@ class AndroidServicesApi
     }
 
     /**
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions.basePlans.offers Monetization.subscriptions.basePlans.offers
-     * */
+     * @phpcs:enable
+     */
     public function getBasePlanOffers(
         AndroidPublisherModelInterface $androidPublisherModel
     ): ?ListSubscriptionOffersResponse {
@@ -98,8 +102,10 @@ class AndroidServicesApi
     }
 
     /**
+     * @phpcs:disable Generic.Files.LineLength.TooLong
      * @throws AndroidServiceException|JsonException
      * @link https://developers.google.com/android-publisher/api-ref/rest/v3/monetization.subscriptions Monetization.subscriptions
+     * @phpcs:enable
      */
     public function getPackageSubscriptions(
         AndroidPublisherModelInterface $androidPublisherModel

--- a/src/DependencyInjection/AndroidServicesExtension.php
+++ b/src/DependencyInjection/AndroidServicesExtension.php
@@ -13,7 +13,10 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class AndroidServicesExtension extends Extension
 {
-    /**@throws Exception */
+    /**
+     * @suppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws Exception
+     */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(

--- a/src/Factory/Authenticator.php
+++ b/src/Factory/Authenticator.php
@@ -6,6 +6,7 @@ namespace IM\Fabric\Bundle\AndroidServicesBundle\Factory;
 
 use Google\Client;
 use Google\Exception;
+use IM\Fabric\Bundle\AndroidServicesBundle\Traits\HasAndroidServiceException;
 use JsonException;
 
 /**
@@ -14,6 +15,8 @@ use JsonException;
  */
 class Authenticator
 {
+    use HasAndroidServiceException;
+
     public function __construct(
         private string $googleCredentials,
         private Client $client
@@ -32,6 +35,10 @@ class Authenticator
     /** @throws JsonException */
     private function getAuthConfig(): array
     {
-        return json_decode($this->googleCredentials, true, 512, JSON_THROW_ON_ERROR);
+        try {
+            return json_decode($this->googleCredentials, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            $this->throwAndroidServiceException($exception->getMessage(), $exception->getCode());
+        }
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,6 +1,6 @@
 parameters:
   app.deployed_env: '%env(string:DEPLOYED_ENV)%'
-  app.google_creds: 'env(GOOGLE_API_SERVICE_ACCOUNT_CREDENTIALS)%'
+  app.google_creds: '%env(GOOGLE_API_SERVICE_ACCOUNT_CREDENTIALS)%'
 services:
   # default configuration for services in *this* file
   _defaults:

--- a/tests/phpunit/Unit/AndroidServiceApiTest.php
+++ b/tests/phpunit/Unit/AndroidServiceApiTest.php
@@ -21,7 +21,10 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/** @SuppressWarnings("LongVariable") */
+/**
+ * @SuppressWarnings("LongVariable")
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * */
 class AndroidServiceApiTest extends TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/phpunit/Unit/Factory/AuthenticatorTest.php
+++ b/tests/phpunit/Unit/Factory/AuthenticatorTest.php
@@ -6,6 +6,7 @@ namespace IM\Fabric\Bundle\AndroidServicesBundle\Test\Unit\Factory;
 
 use Google\Client;
 use Google\Exception;
+use IM\Fabric\Bundle\AndroidServicesBundle\Exception\AndroidServiceException;
 use IM\Fabric\Bundle\AndroidServicesBundle\Factory\Authenticator;
 use JsonException;
 use Mockery;
@@ -30,11 +31,13 @@ class AuthenticatorTest extends TestCase
         "client_x509_cert_url": "mock_url"
     }';
 
-    /**@throws Exception*/
+    /**@throws Exception
+     * @throws JsonException
+     */
     public function testItThrowsAnExceptionIfTheCertIsNotValidJson(): void
     {
         $client = Mockery::mock(Client::class);
-        $this->expectException(JsonException::class);
+        $this->expectException(AndroidServiceException::class);
         $unit = new Authenticator('bad json key', $client);
         $unit->getAuthenticatedClient(self::MOCK_SCOPE);
     }


### PR DESCRIPTION
>[!note]
> Bugfix - add missing `%` in service the yaml that was stoping the variable from being properly loaded
> Feat - Throw a  `throwAndroidServiceException` when geting `AuthConfig`
> fix - PHPCS 


----
<img width="1023" height="361" alt="image" src="https://github.com/user-attachments/assets/b95b4f96-38c5-479b-a754-65fbd5017ef2" />
